### PR TITLE
Always use a context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python:
   - 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,17 @@
 dist: bionic
 language: python
-
 python:
-  - 2.8
   - 3.5
   - 3.6
   - 3.7
-  - 3.8
-
-# safelist branch to build
-branches:
-  only:
-    - master
-
 install:
   - python setup.py sdist
   - pip install dist/`python setup.py --name`-`python setup.py --version`.tar.gz
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
-
 before_script: pip install .
-
 script:
   - coverage run --source boscli setup.py test
   - coverage report -m
-
 after_script:
   - coveralls --verbose
-
-notifications:
-  email:
-    - bifer@alea-soluciones.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 dist: bionic
 language: python
 python:
-  - 2.8
   - 3.5
   - 3.6
   - 3.7
-  - 3.8
 install:
   - python setup.py sdist
   - pip install dist/`python setup.py --name`-`python setup.py --version`.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
   - pypy
 install:
   - python setup.py sdist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
-dist: xenial
+dist: bionic
 language: python
 python:
-  - 2.7
+  - 2.8
   - 3.5
   - 3.6
   - 3.7
+  - 3.8
 install:
   - python setup.py sdist
   - pip install dist/`python setup.py --name`-`python setup.py --version`.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,9 @@ dist: xenial
 language: python
 python:
   - 2.7
-  - 3.3
-  - 3.4
   - 3.5
   - 3.6
   - 3.7
-  - pypy
 install:
   - python setup.py sdist
   - pip install dist/`python setup.py --name`-`python setup.py --version`.tar.gz

--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ $ mamba
 
 Boscli is released under the `MIT license <http://en.wikipedia.org/wiki/MIT_License>`_.
 
-##Contribute
+## Contribute
 
 If you'd like to contribute, fork [repository](http://github.com/aleasoluciones/boscli), and send a pull request.

--- a/boscli/command.py
+++ b/boscli/command.py
@@ -95,10 +95,13 @@ class Command(object):
     def context_match(self, context):
         if self.always is True:
             return True
-        if self.context_name and not context:
+
+        if self.context_name and context.is_default():
             return False
-        if context is None:
+
+        if not self.context_name and context.is_default():
             return True
+
         if context.has_name(self.context_name):
             return True
         return False

--- a/boscli/interpreter.py
+++ b/boscli/interpreter.py
@@ -13,6 +13,9 @@ class Context(object):
         self._prompt = prompt
         self.data = {}
 
+    def is_default(self):
+        return False
+
     def has_name(self, context_name):
         return self.context_name == context_name
 
@@ -23,7 +26,15 @@ class Context(object):
         return self.context_name
 
     def __str__(self):
-        return "Context%s" % self.context_name
+        return "Context:%s" % self.context_name
+
+
+class DefaultContext(Context):
+    def __init__(self, prompt=None):
+        super().__init__('Default', prompt=prompt)
+
+    def is_default(self):
+        return True
 
 
 class Interpreter(object):
@@ -35,7 +46,7 @@ class Interpreter(object):
                  prompt=''):
         self._commands = []
         self.parser = parser
-        self.context = []
+        self.context = [DefaultContext(prompt)]
         self._prompt = prompt
         self.filter_factory = filter_factory
         self.output_stream = output_stream

--- a/boscli/interpreter.py
+++ b/boscli/interpreter.py
@@ -58,10 +58,10 @@ class Interpreter(object):
         self.context.append(Context(context_name, prompt))
 
     def pop_context(self):
-        try:
-            self.context.pop()
-        except IndexError:
+        # We never let the default context be removed
+        if len(self.context) == 1:
             raise exceptions.NotContextDefinedError()
+        self.context.pop()
 
     def exit(self):
         raise exceptions.EndOfProgram()

--- a/boscli/interpreter.py
+++ b/boscli/interpreter.py
@@ -10,7 +10,7 @@ class Context(object):
 
     def __init__(self, context_name, prompt=None):
         self.context_name = context_name
-        self._prompt = prompt
+        self.prompt = prompt if prompt else self.context_name
         self.data = {}
 
     def is_default(self):
@@ -18,12 +18,6 @@ class Context(object):
 
     def has_name(self, context_name):
         return self.context_name == context_name
-
-    @property
-    def prompt(self):
-        if self._prompt:
-            return self._prompt
-        return self.context_name
 
     def __str__(self):
         return "Context:%s" % self.context_name
@@ -47,7 +41,6 @@ class Interpreter(object):
         self._commands = []
         self.parser = parser
         self.context = [DefaultContext(prompt)]
-        self._prompt = prompt
         self.filter_factory = filter_factory
         self.output_stream = output_stream
 
@@ -173,8 +166,8 @@ class Interpreter(object):
 
     @property
     def prompt(self):
-        return self.actual_context().prompt if self.actual_context() else self._prompt
+        return self.actual_context().prompt
 
     @prompt.setter
     def prompt(self, value):
-        self._prompt = value
+        self.actual_context().prompt = value

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-mamba==0.8.6
+mamba
 pyhamcrest
 doublex
 coverage

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ class MambaTest(TestCommand):
         mamba.cli.main()
 
 setup(name='boscli',
-      version='0.9.2',
+      version='0.9.3',
       author='Alea Soluciones SLL',
       author_email='eduardo.ferro.aldama@gmail.com',
       description ='Extensible command line processor for "ad hoc" shells creation',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ class MambaTest(TestCommand):
         mamba.cli.main()
 
 setup(name='boscli',
-      version='0.9.1',
+      version='0.9.2',
       author='Alea Soluciones SLL',
       author_email='eduardo.ferro.aldama@gmail.com',
       description ='Extensible command line processor for "ad hoc" shells creation',

--- a/spec/context_spec.py
+++ b/spec/context_spec.py
@@ -49,9 +49,17 @@ with context('Interpreter context'):
             assert_that(self.context_commands.cmd1, never(called()))
             assert_that(self.context_commands.cmd2, never(called()))
 
+        with it('execute commands in the defualt context'):
+            self.interpreter.eval('exit')
+
+            assert_that(self.main_commands.exit, called().with_args(ANY_ARG))
+
         with describe('when pop context'):
             with it('raise error because no context defined'):
                 try:
+                    # pop the default context
+                    self.interpreter.pop_context()
+
                     self.interpreter.pop_context()
                     raise "Should raise exception"
                 except exceptions.NotContextDefinedError:

--- a/spec/context_spec.py
+++ b/spec/context_spec.py
@@ -55,11 +55,8 @@ with context('Interpreter context'):
             assert_that(self.main_commands.exit, called().with_args(ANY_ARG))
 
         with describe('when pop context'):
-            with it('raise error because no context defined'):
+            with it('raise error when we already are at top/initial level'):
                 try:
-                    # pop the default context
-                    self.interpreter.pop_context()
-
                     self.interpreter.pop_context()
                     raise "Should raise exception"
                 except exceptions.NotContextDefinedError:

--- a/spec/interpreter_spec.py
+++ b/spec/interpreter_spec.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from hamcrest import none, has_length, has_items, is_not
+from hamcrest import none, has_length, has_items, is_not, is_
 from doublex import Spy, assert_that, called, Stub, when, ANY_ARG
 
 import boscli
@@ -216,3 +216,29 @@ with describe('Interpreter'):
                 assert_that(self.cmds_implementation.cmd1,
                                         called().with_args('firstOp', 'secondOp', tokens=['cmd1', 'firstOp', 'secondOp'], interpreter=self.interpreter))
 
+    with context('prompt management'):
+        with describe('when we are at the initial context'):
+            with it('have a default prompt'):
+                assert_that(self.interpreter.prompt, is_('Default'))
+
+            with it('allow change the prompt'):
+                self.interpreter.prompt = 'prompt1'
+
+                assert_that(self.interpreter.prompt, is_('prompt1'))
+
+            with it('maintain the prompts of previous contexts'):
+                self.interpreter.prompt = 'default'
+
+                assert_that(self.interpreter.prompt, is_('default'))
+
+                self.interpreter.push_context('context1', "prompt_context1")
+                assert_that(self.interpreter.prompt, is_('prompt_context1'))
+
+                self.interpreter.push_context('context2', "prompt_context2")
+                assert_that(self.interpreter.prompt, is_('prompt_context2'))
+
+                self.interpreter.pop_context()
+                assert_that(self.interpreter.prompt, is_('prompt_context1'))
+
+                self.interpreter.pop_context()
+                assert_that(self.interpreter.prompt, is_('default'))


### PR DESCRIPTION
Use a default context for all the commands... So the context feature is more homogeneous and we can use the context to storage info always.

Updated the python versions and updated the Travis distro.