### PR TITLE
Always autocomplete when the user hits tab

### DIFF
--- a/boscli/interpreter.py
+++ b/boscli/interpreter.py
@@ -172,8 +172,7 @@ class Interpreter:
             return {' '}
 
         for command in self._partial_match(line_to_complete):
-            if command not in self._select_perfect_matching_commands(tokens):
-                completions.update(command.complete(tokens, self.actual_context()))
+            completions.update(command.complete(tokens, self.actual_context()))
         return completions
 
     @property

--- a/spec/autocomplete_spec.py
+++ b/spec/autocomplete_spec.py
@@ -32,14 +32,6 @@ with describe('Autocomplete'):
         with it('not complete unknown command'):
             assert_that(self.interpreter.complete('unknown command'), has_length(0))
 
-        with describe('when autocompleting matching and partial matching command'):
-            with it('completes partial matching command with space'):
-                self.interpreter.add_command(
-                    Command(['cmd', CompleteCompletionsType(['op1', 'op2']), 'last'], self.implementation.irrelevant_cmd))
-                self.interpreter.add_command(
-                    Command(['cmd', CompleteCompletionsType(['op1', 'op2'])], self.implementation.irrelevant_cmd))
-
-                assert_that(self.interpreter.complete('cmd op1'), contains('op1 '))
 
     with describe('when autocompleting type with completions'):
         with it('completes with the final space if is not the last token'):


### PR DESCRIPTION
The current behavior of the Boscli implies that in cases where there is a perfect match and other regular matches, if the user presses the tab, the autocomplete does not occur. This was quite uncomfortable in cases where, for example, you accepted a list but also a string (OrType(OptionalType,StringType)). In those cases, since the string accepted any string, whenever you pressed tab, it didn't work if that type was the last word of the command since it implied that there was always a perfect match (string) with priority.

The behavior has changed to simplify it so that if the user presses TAB, regardless of other considerations, it means they want to autocomplete, so we autocomplete and show the options. (If they didn't want to autocomplete), I think pressing enter would work.

The change has involved removing a test that no longer made sense and eliminating the condition of having a perfect match before generating the autocompletions.