### PR TITLE
Corrected RegexType.partial_match

### DIFF
--- a/boscli/basic_types.py
+++ b/boscli/basic_types.py
@@ -134,4 +134,4 @@ class RegexType(BaseType):
         return not self.regex.match(word) is None
 
     def partial_match(self, word, context, partial_line=None):
-        return self.match(word, partial_line)
+        return self.match(word, context, partial_line)

--- a/boscli/exceptions.py
+++ b/boscli/exceptions.py
@@ -12,7 +12,7 @@ class AmbiguousCommandError(EvalError):
         super(AmbiguousCommandError, self).__init__(matching_commands)
 
 
-class SintaxError(EvalError):
+class SyntaxError(EvalError):
     pass
 
 

--- a/boscli/interpreter.py
+++ b/boscli/interpreter.py
@@ -65,7 +65,7 @@ class Interpreter:
         for token in tokens:
             if token == FILTER_SEP:
                 if sep_found:
-                    raise exceptions.SintaxError()
+                    raise exceptions.SyntaxError()
                 sep_found = True
                 continue
             if sep_found:
@@ -80,9 +80,9 @@ class Interpreter:
                 return self.filter_factory.create_include_filter(filter_tokens[1], self.output_stream)
             if 'exclude'.startswith(filter_tokens[0]):
                 return self.filter_factory.create_exclude_filter(filter_tokens[1], self.output_stream)
-            raise exceptions.SintaxError()
+            raise exceptions.SyntaxError()
         except IndexError:
-            raise exceptions.SintaxError()
+            raise exceptions.SyntaxError()
 
     def _matching_command(self, tokens, line_text):
         perfect_matching_commands = self._select_perfect_matching_commands(tokens)

--- a/boscli/readlinecli/readlinecli.py
+++ b/boscli/readlinecli/readlinecli.py
@@ -89,7 +89,7 @@ class ReadlineCli:
         timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
         filename = os.path.expanduser(self.histfile + ".audit")
         with open(filename, "a") as file:
-            file.write(f"{timestamp} - {command}\n")
+            file.write("{} - {}\n".format(timestamp, command))
 
     def interact(self):
         while True:

--- a/spec/basic_types_spec.py
+++ b/spec/basic_types_spec.py
@@ -257,6 +257,23 @@ with describe('Basic Types'):
             assert_that(self.regex_type.partial_match('op3', self.context), is_(True))
             assert_that(self.regex_type.partial_match('op4', self.context), is_(False))
 
+        with it('propagates context and partial_line to match'):
+            class TestRegexType(basic_types.RegexType):
+                def __init__(self):
+                    super(TestRegexType, self).__init__('op[1-3]')
+                    self.recorded = None
+
+                def match(self, word, context, partial_line=None):
+                    self.recorded = (word, context, partial_line)
+                    return True
+
+            regex_type = TestRegexType()
+
+            result = regex_type.partial_match('op1', self.context, partial_line=['op'])
+
+            assert_that(result, is_(True))
+            assert_that(regex_type.recorded, is_(('op1', self.context, ['op'])))
+
         with context('Representation'):
             with it('has a default representation'):
                 assert_that(str(basic_types.RegexType('regEx')), contains_string('RegexType'))

--- a/spec/interpreter_filters_spec.py
+++ b/spec/interpreter_filters_spec.py
@@ -23,19 +23,19 @@ with describe('Interpreter filters'):
         with it('raise sintax error when two filters'):
             try:
                 self.interpreter.eval('cmd key | include regexp | exclude regexp')
-            except exceptions.SintaxError:
+            except exceptions.SyntaxError:
                 pass
 
         with it('raise sintax error when incomplete filter'):
             try:
                 self.interpreter.eval('cmd key | include')
-            except exceptions.SintaxError:
+            except exceptions.SyntaxError:
                 pass
 
         with it('raise sintax error when unknown filter'):
             try:
                 self.interpreter.eval('cmd key | unknown_filter regexp')
-            except exceptions.SintaxError:
+            except exceptions.SyntaxError:
                 pass
 
     with context('command execution'):


### PR DESCRIPTION
Corrected RegexType.partial_match to forward both the context and partial input to match, enabling proper reuse of context during regex validation

Introduced a regression test that checks propagation of the context and partial line through partial_match for regular expressions